### PR TITLE
bugfix - no permalinks outside project directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ Metalsmith(__dirname)
     }))
     .use(markdown())
     .use(permalinks({
-        pattern: ':collection/:title'
+        pattern: './:collection/:title'
     }))
     .use(templates('handlebars'))
     .use(sass({


### PR DESCRIPTION
Right now it's possible for metalsmith-permalinks to try to create folder outside the current directory of the project, [as mentioned in this issue](https://github.com/segmentio/metalsmith-permalinks/issues/41). I think this is the error pointed out in #3, since I was having the same one and was able to fix it with this. 
